### PR TITLE
System is the default allocator at `1.36.0-nightly`.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,5 @@
 #![allow(unused_imports)]
 
-#![feature(alloc_system)]
-extern crate alloc_system;
-
 extern crate pairing;
 extern crate bellman;
 extern crate rand;


### PR DESCRIPTION
https://blog.rust-lang.org/2019/01/17/Rust-1.32.0.html#jemalloc-is-removed-by-default